### PR TITLE
Fixed: Reset input field after URL submission

### DIFF
--- a/src/components/Demo.jsx
+++ b/src/components/Demo.jsx
@@ -32,7 +32,12 @@ const Demo = () => {
       (item) => item.url === article.url
     );
 
-    if (existingArticle) return setArticle(existingArticle);
+    // if (existingArticle) return setArticle(existingArticle);
+    if(existingArticle) {
+      setArticle(existingArticle)
+      setArticle({...article, url:""})
+      return;
+    }
 
     const { data } = await getSummary({ articleUrl: article.url });
     if (data?.summary) {
@@ -43,6 +48,9 @@ const Demo = () => {
       setArticle(newArticle);
       setAllArticles(updatedAllArticles);
       localStorage.setItem("articles", JSON.stringify(updatedAllArticles));
+
+
+      setArticle({ ...article, url: "" });
     }
   };
 


### PR DESCRIPTION
This update clears the URL input field after submitting an article URL. Previously, the input field retained the submitted URL, which could cause confusion for users if they wanted to input a new URL. By resetting the input field to an empty string after the form submission, the user experience is improved, allowing users to more easily submit multiple URLs without manually clearing the field each time.


Before: 
![Screenshot (229)](https://github.com/user-attachments/assets/0bfd8a23-bd1e-4b46-aafe-43ba0ed44de9)


After: 
![Screenshot (228)](https://github.com/user-attachments/assets/eb0e8f8f-b807-4f76-8cae-c3e6b71d5d94)
